### PR TITLE
bug: refactor stat_tracker to be able to use methods across CSV's

### DIFF
--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -1,14 +1,20 @@
 require 'csv'
 
 class StatTracker
- attr_reader :data
+ attr_reader :games, :teams, :game_teams
 
-  def initialize(filepath)
-    @data = CSV.read(filepath, headers: true, header_converters: :symbol)
+  def initialize(games, teams, game_teams)
+    @games = games
+    @teams = teams
+    @game_teams = game_teams
   end
 
   def self.from_csv(locations)
-    locations.map {|key, filepath| [key, StatTracker.new(filepath)]}.to_h
+    StatTracker.new(
+    CSV.read(locations[:games], headers: true, header_converters: :symbol),
+    CSV.read(locations[:teams], headers: true, header_converters: :symbol),
+    CSV.read(locations[:game_teams], headers: true, header_converters: :symbol)
+  )
   end
 
 end

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -2,23 +2,7 @@ require './lib/stat_tracker'
 
 RSpec.describe StatTracker do
 
-  it '1. exists' do
-    team_path = './data/teams.csv'
-    location = team_path
-    stat_tracker = StatTracker.new(location)
-
-    expect(stat_tracker).to be_an_instance_of StatTracker
-  end
-
-  it '2. can load filepath' do
-    team_path = './data/teams.csv'
-    location = team_path
-    stat_tracker = StatTracker.new(location)
-    # require "pry"; binding.pry
-    expect(stat_tracker.data.headers).to eq [:team_id,:franchiseid,:teamname,:abbreviation,:stadium,:link]
-  end
-
-  it '3. can load an array of multiple CSVs' do
+  before :each do
     game_path = './data/games_dummy.csv'
     team_path = './data/teams.csv'
     game_teams_path = './data/game_teams_dummy.csv'
@@ -29,10 +13,16 @@ RSpec.describe StatTracker do
       game_teams: game_teams_path
     }
 
-    stat_tracker = StatTracker.from_csv(locations)
-    
-    expect(stat_tracker).to be_a Hash
-    expect(stat_tracker.keys).to eq([:games, :teams, :game_teams])
-    expect(stat_tracker.values).to all be_an_instance_of StatTracker
+    @stat_tracker = StatTracker.from_csv(locations)
+  end
+
+  it '1. exists' do
+    expect(@stat_tracker).to be_an_instance_of StatTracker
+  end
+
+  it '3. can load an array of multiple CSVs' do
+    expect(@stat_tracker.games).to be_a(CSV::Table)
+    expect(@stat_tracker.teams).to be_a(CSV::Table)
+    expect(@stat_tracker.game_teams).to be_a(CSV::Table)
   end
 end


### PR DESCRIPTION
I hope this doesn't mess anyone up too much. After getting deeper in to writing methods for statistics, I found out we need to be able to create statistics across the different CSV's. And we can't call a single instance methods across multiple instances (the `:games`, `:teams`, and `:games_teams` instances). I refactored the tests and the code so that when calling `self.from_csv`, one instance of `StatTracker` is created that has three instance methods (`@games`, `@teams`, and `@game_teams`). 

Please look it over and let me know if there is anything else I'm missing. I think this should be what we need to get through Iteration 2. 